### PR TITLE
Fix Facebook login and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,24 @@
 
 A stock game for reading stocks information, deciding your stocks portfolio and competing with others.
 
-Website URL : https://stock-arena.ddns.net/ or http://stock-arena.ddns.net/
+Website URL : https://stock-arena.duckdns.org/
 
 ## Table of content
-* [Technologies](#technologies)
-* [Structure](#structure)
-* [Database design](#database-design)
-* [Features and Demonstration](#Features-and-Demonstration)
-* [Guest account](#Guest-account)
-* [Contact](#Contact)
+- [Stock Arena](#stock-arena)
+  - [Table of content](#table-of-content)
+  - [Technologies](#technologies)
+    - [Backend](#backend)
+    - [Frontend](#frontend)
+    - [Realitime Web Application](#realitime-web-application)
+    - [Database](#database)
+    - [Web Crawl](#web-crawl)
+    - [Test](#test)
+    - [Others](#others)
+  - [Structure](#structure)
+  - [Database design](#database-design)
+  - [Features and Demonstration](#features-and-demonstration)
+  - [Guest account](#guest-account)
+  - [Contact](#contact)
 
 
 ## Technologies
@@ -26,8 +35,8 @@ Website URL : https://stock-arena.ddns.net/ or http://stock-arena.ddns.net/
 * CSS
 * JavaScript
 
-### Realitime Web Application 
-* Socket io
+### Realtime Web Application
+* Socket.IO
 
 ### Database
 * MySQL
@@ -42,7 +51,7 @@ Website URL : https://stock-arena.ddns.net/ or http://stock-arena.ddns.net/
 * Chai
 
 ### Others
-* Plot: D3, Hicharts
+* Plot: D3, Highcharts
 * Facebook login API
 
 
@@ -95,5 +104,5 @@ Website URL : https://stock-arena.ddns.net/ or http://stock-arena.ddns.net/
 * Account password: stock1234
 
 ## Contact
-* Authur: Ting-Yuan Hsiao
+* Author: Ting-Yuan Hsiao
 * Email: yuanchris1@gmail.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock",
   "version": "1.0.0",
-  "description": "chris\r http://18.182.189.165",
+  "description": "Stock Arena - A stock trading game",
   "main": "sample.js",
   "scripts": {
     "test": "set NODE_ENV=test&&mocha --exit",

--- a/public/js/sign.js
+++ b/public/js/sign.js
@@ -4,7 +4,7 @@ window.fbAsyncInit = function () {
     appId: '249384742955352',
     cookie: true,
     xfbml: true,
-    version: 'v7.0',
+    version: 'v21.0',
   });
   FB.AppEvents.logPageView();
 };

--- a/public/sign.html
+++ b/public/sign.html
@@ -30,7 +30,7 @@
   <main>
 
     <div id="fb-root"></div>
-    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/zh_TW/sdk.js#xfbml=1&version=v7.0" nonce="0Bqwgro1"></script>
+    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/zh_TW/sdk.js#xfbml=1&version=v21.0" nonce="0Bqwgro1"></script>
 
     <div class="signin">
       <h2>登入</h2>


### PR DESCRIPTION
## Summary
- Update Facebook SDK version from v7.0 to v21.0 to restore Facebook login functionality
- Fix typos in README (Realtime, Highcharts, Author)
- Remove old hardcoded IP from package.json description

## Changes
- `public/sign.html` - Update Facebook SDK version to v21.0
- `public/js/sign.js` - Update FB.init version to v21.0
- `README.md` - Fix typos: Realitime → Realtime, Hicharts → Highcharts, Authur → Author
- `package.json` - Update description, remove old IP address

## Note
Facebook Developer console also needs to be updated separately:
- App domains → stock-arena.duckdns.org
- Valid OAuth Redirect URIs → https://stock-arena.duckdns.org/
- Enable JavaScript SDK login + add allowed domain